### PR TITLE
Fixed spelling error in Crank-Nicolson (no h) scheme

### DIFF
--- a/qmat/qcoeff/butcher.py
+++ b/qmat/qcoeff/butcher.py
@@ -286,7 +286,7 @@ class MidPoint(RK):
 @registerRK
 class TRAP(RK):
     """Trapeze method (cf Wikipedia)"""
-    aliases = ["TRAPZ", "CN", "CrankNicholson"]
+    aliases = ["TRAPZ", "CN", "CrankNicolson"]
     A = [[0, 0],
          [1/2, 1/2]]
     b = [1/2, 1/2]


### PR DESCRIPTION
Thanks to @mattfeldt for pointing this out.