### PR TITLE
Switch to `qmat` in SWEET

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ and the current [Development Roadmap](https://qmat.readthedocs.io/en/latest/devd
 ## Projects relying on `qmat`
 
 - [pySDC](https://github.com/Parallel-in-Time/pySDC) : _Python implementation of the spectral deferred correction (SDC) approach and its flavors, esp. the multilevel extension MLSDC and PFASST._
+- [SWEET](https://gitlab.inria.fr/sweet/sweet) : _Shallow Water Equation Environment for Tests, Awesome! (C++)_
 
 ## Links
 

--- a/docs/devdoc/roadmap.md
+++ b/docs/devdoc/roadmap.md
@@ -21,15 +21,15 @@ Detailed description of all specific versions and their associated changes is av
 - ✅ citation file and zenodo releases
 - ✅ integration of `qmat` into [pySDC](https://github.com/Parallel-in-Time/pySDC), _c.f_ [associated PR](https://github.com/Parallel-in-Time/pySDC/pull/445)
 - ✅ refined design for $Q_\Delta$ generators
-- full documentation of classes and functions
+- ✅ full documentation of classes and functions
 - finalization of extended usage tutorials ($S$-matrix, `dTau` coefficient for initial sweep, prolongation)
 - ✅ full definition and documentation of the version update pipeline
 
 **Status 5 - Production/Stable** : `v1.0.*`
 
 - base console script interfacing `qmat` API for $Q$-coefficients and SDC coefficients generation (with IMEX)
-- integration of `qmat` into [SWEET](https://gitlab.inria.fr/sweet/sweet)
-- use of `qmat` for [Dedalus](https://github.com/DedalusProject/dedalus) IMEX SDC time-steppers developed within [pySDC](https://github.com/Parallel-in-Time/pySDC)
+- ✅ integration of `qmat` into [SWEET](https://gitlab.inria.fr/sweet/sweet)
+- ✅ use of `qmat` for [Dedalus](https://github.com/DedalusProject/dedalus) IMEX SDC time-steppers developed within [pySDC](https://github.com/Parallel-in-Time/pySDC)
 - distribution to other people using former version of the core `qmat` code (_e.g_ Alex Brown from Exeter, ...)
 - addition of a few advanced usage tutorials :
     - `qmat` for non-linear ODE

--- a/qmat/qdelta/diag.py
+++ b/qmat/qdelta/diag.py
@@ -12,7 +12,7 @@ Examples
 >>> from qmat import genQDeltaCoeffs
 >>> QDelta = genQDeltaCoeffs("MIN-SR-NS", nodes=coll.nodes)
 >>>
->>> from qmat.qdelta.min import MIN_SR_S, MIN_SR_FLEX
+>>> from qmat.qdelta.diag import MIN_SR_S, MIN_SR_FLEX
 >>> minSRS= MIN_SR_S(coll.nNodes, coll.nodeType, coll.quadType)
 >>> QDelta = minSRS.getQDelta()
 >>> minSRFLEX = MIN_SR_FLEX(coll.nNodes, coll.nodeType, coll.quadType)
@@ -30,8 +30,7 @@ from qmat.qcoeff.collocation import Collocation
 def check(k):
     """Utility function to check k parameter for k-dependent generators"""
     if k is None: k = 1
-    if k < 1:
-        raise ValueError(f"k must be greater than 0 ({k})")
+    if k < 1: raise ValueError(f"k must be greater than 0 ({k})")
     return k
 
 
@@ -291,3 +290,38 @@ class FlexJumper(Jumper):
         k = check(k)
         divider = 1 if k == 1 else 2*(k-1)
         return np.diag(self.nodes)/divider
+
+
+@register
+class DNODES(MIN_SR_NS):
+    """Diagonal coefficients build on divided node (1 here)"""
+    divider = 1
+    aliases = ["DNODES-1"]
+
+    def computeQDelta(self, k=None):
+        return np.diag(self.nodes)/self.divider
+
+@register
+class DNODES2(DNODES):
+    """Diagonal coefficients build on divided node (2 here)"""
+    divider = 2
+    aliases = ["DNODES-2"]
+
+@register
+class DNODES3(DNODES):
+    """Diagonal coefficients build on divided node (3 here)"""
+    divider = 3
+    aliases = ["DNODES-3"]
+
+@register
+class DNODES4(DNODES):
+    """Diagonal coefficients build on divided node (4 here)"""
+    divider = 4
+    aliases = ["DNODES-4"]
+
+@register
+class DNODES5(DNODES):
+    """Diagonal coefficients build on divided node (5 here)"""
+    divider = 5
+    aliases = ["DNODES-5"]
+

--- a/tests/test_qdelta/test_diag.py
+++ b/tests/test_qdelta/test_diag.py
@@ -146,3 +146,24 @@ def testJumper(nNodes, nodeType, quadType):
 
     assert np.allclose(QDeltas2[0], QDeltasFlex[0])
     assert np.allclose(QDeltas2[1:], QDeltas[:-1])
+
+
+@pytest.mark.parametrize("quadType", ["GAUSS", "RADAU-RIGHT"])
+@pytest.mark.parametrize("nodeType", NODE_TYPES)
+@pytest.mark.parametrize("nNodes", [2, 3, 4])
+@pytest.mark.parametrize("divider", [1, 2, 3, 4, 5])
+def testDNODES(divider, nNodes, nodeType, quadType):
+    coll = Collocation(nNodes=nNodes, nodeType=nodeType, quadType=quadType)
+    nodes = coll.nodes
+    
+    Generator = {
+        1: module.DNODES,
+        2: module.DNODES2,
+        3: module.DNODES3,
+        4: module.DNODES4,
+        5: module.DNODES5,
+    }[divider]
+    gen:module.DNODES = Generator(nodes=nodes)
+    QDeltas = gen.genCoeffs()
+
+    assert np.allclose(QDeltas, np.diag(nodes)/divider)

--- a/tests/test_qdelta/test_min.py
+++ b/tests/test_qdelta/test_min.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 from qmat.qdelta import QDELTA_GENERATORS
-import qmat.qdelta.min as module
+import qmat.qdelta.diag as module
 from qmat.qcoeff.collocation import Collocation
 from qmat.nodes import NODE_TYPES, QUAD_TYPES
 


### PR DESCRIPTION
Changes for the use of `qmat` to generate SDC coefficients in [SWEET](https://gitlab.inria.fr/sweet/sweet)