### PR TITLE
Added function for generating sparse interpolation matrices

### DIFF
--- a/qmat/lagrange.py
+++ b/qmat/lagrange.py
@@ -530,7 +530,6 @@ class LagrangeApproximation(object):
             return D2
         else:
             return D1, D2
-        return PInter
 
 
 def getSparseInterpolationMatrix(inPoints, outPoints, order):
@@ -557,7 +556,7 @@ def getSparseInterpolationMatrix(inPoints, outPoints, order):
     """
     import scipy.sparse as sp
 
-    assert order <= len(inPoints), f'Cannot interpolate {inPoints} to order {order}!'
+    assert order <= len(inPoints), f'Cannot interpolate {len(inPoints)} to order {order}! Please reduce order'
 
     A = sp.lil_matrix((len(outPoints), len(inPoints)))
     lastInterpolationLine = None

--- a/qmat/lagrange.py
+++ b/qmat/lagrange.py
@@ -530,3 +530,52 @@ class LagrangeApproximation(object):
             return D2
         else:
             return D1, D2
+        return PInter
+
+
+def getSparseInterpolationMatrix(inPoints, outPoints, order):
+    """
+    Get a sparse interpolation matrix from `inPoints` to `outPoints` of order
+    `order` using barycentric Lagrange interpolation.
+
+    The matrix will have `order` entries per line, and tends to be banded when
+    both `inPoints` and `outPoints` are equispaced and cover the same interval.
+
+    Parameters
+    ----------
+        inPoints : np.1darray
+            The points you want to interpolate from
+        outPoints : np.1darray
+            The points you want to interpolate to
+        order : int
+            Order of the interpolation
+
+    Returns
+    -------
+    A : scipy.sparse.csc_matrix(len(outPoints), len(inPoints))
+        Sparse interpolation matrix
+    """
+    import scipy.sparse as sp
+
+    assert order <= len(inPoints), f'Cannot interpolate {inPoints} to order {order}!'
+
+    A = sp.lil_matrix((len(outPoints), len(inPoints)))
+    lastInterpolationLine = None
+    lastClosestPoints = None
+
+    for i in range(len(outPoints)):
+        closestPointsIdx = np.sort(np.argsort(np.abs(inPoints - outPoints[i]))[:order])
+        closestPoints = inPoints[closestPointsIdx] - outPoints[i]
+
+        if lastClosestPoints is not None and np.allclose(closestPoints, lastClosestPoints):
+            interpolationLine = lastInterpolationLine
+        else:
+            interpolator = LagrangeApproximation(points = closestPoints)
+            interpolationLine = interpolator.getInterpolationMatrix([0])[0]
+
+            lastInterpolationLine = interpolationLine
+            lastClosestPoints = closestPoints
+
+        A[i, closestPointsIdx] = interpolationLine
+    
+    return A.tocsc()


### PR DESCRIPTION
This PR adds a simple function for getting sparse interpolation matrices using the barycentric Lagrange interpolation that is already implemented in `qmat`.
It loops through every point you want to interpolate to, gathers the `k` nearest neighbors on the grid you interpolate from, and puts the interpolating coefficients in a line of the interpolation matrix. Afterwards, interpolation of order `k` can be achieved by SpMV.
For certain grids, the distances between nodes to be interpolated to and their `k` nearest neighbors on the grid you interpolate from repeat for multiple entries. In this case, this function will simple copy existing interpolating coefficients rather then computing them from scratch.

Tests are included that make sure the interpolation is of order `k` by testing that a polynomial of order `k` is interpolated exactly, whereas a polynomial of order `k+1` is not, unless both grids match, in which case the interpolation is always exact.
The latter case is needed to test the reuse of interpolating coefficients.