### PR TITLE
Added option for periodic grids to sparse interpolation matrices

### DIFF
--- a/qmat/lagrange.py
+++ b/qmat/lagrange.py
@@ -537,7 +537,7 @@ class LagrangeApproximation(object):
         return self.getDerivativeMatrix(*args, **kwargs)
 
 
-def getSparseInterpolationMatrix(inPoints, outPoints, order, grid_period=-1):
+def getSparseInterpolationMatrix(inPoints, outPoints, order, gridPeriod=-1):
     """
     Get a sparse interpolation matrix from `inPoints` to `outPoints` of order
     `order` using barycentric Lagrange interpolation.
@@ -570,10 +570,10 @@ def getSparseInterpolationMatrix(inPoints, outPoints, order, grid_period=-1):
     lastClosestPoints = None
 
     for i in range(len(outPoints)):
-        if grid_period > 0:
-            pathL = (inPoints - grid_period - outPoints[i] % grid_period)
-            pathR = (inPoints + grid_period - outPoints[i] % grid_period)
-            pathC = (inPoints - outPoints[i] % grid_period)
+        if gridPeriod > 0:
+            pathL = (inPoints - gridPeriod - outPoints[i] % gridPeriod)
+            pathR = (inPoints + gridPeriod - outPoints[i] % gridPeriod)
+            pathC = (inPoints - outPoints[i] % gridPeriod)
             path = np.append(np.append(pathR, pathL), pathC)
             dist = np.abs(path)
             _closestPointsIdx = np.sort(np.argsort(dist)[:order])

--- a/qmat/lagrange.py
+++ b/qmat/lagrange.py
@@ -537,7 +537,7 @@ class LagrangeApproximation(object):
         return self.getDerivativeMatrix(*args, **kwargs)
 
 
-def getSparseInterpolationMatrix(inPoints, outPoints, order):
+def getSparseInterpolationMatrix(inPoints, outPoints, order, grid_period=-1):
     """
     Get a sparse interpolation matrix from `inPoints` to `outPoints` of order
     `order` using barycentric Lagrange interpolation.
@@ -553,6 +553,8 @@ def getSparseInterpolationMatrix(inPoints, outPoints, order):
             The points you want to interpolate to
         order : int
             Order of the interpolation
+        grid_period : float
+            Period of the grid. Negative values indicate non-periodic grids
 
     Returns
     -------
@@ -568,10 +570,21 @@ def getSparseInterpolationMatrix(inPoints, outPoints, order):
     lastClosestPoints = None
 
     for i in range(len(outPoints)):
-        closestPointsIdx = np.sort(np.argsort(np.abs(inPoints - outPoints[i]))[:order])
-        closestPoints = inPoints[closestPointsIdx] - outPoints[i]
+        if grid_period > 0:
+            pathL = (inPoints - grid_period - outPoints[i] % grid_period)
+            pathR = (inPoints + grid_period - outPoints[i] % grid_period)
+            pathC = (inPoints - outPoints[i] % grid_period)
+            path = np.append(np.append(pathR, pathL), pathC)
+            dist = np.abs(path)
+            _closestPointsIdx = np.sort(np.argsort(dist)[:order])
+            closestPointsIdx = _closestPointsIdx % len(inPoints)
+            closestPoints, sorting = np.unique(path[_closestPointsIdx], return_index=True)
+            closestPointsIdx = closestPointsIdx[sorting]
+        else:
+            closestPointsIdx = np.sort(np.argsort(np.abs(inPoints - outPoints[i]))[:order])
+            closestPoints = inPoints[closestPointsIdx] - outPoints[i]
 
-        if lastClosestPoints is not None and np.allclose(closestPoints, lastClosestPoints):
+        if lastClosestPoints is not None and len(closestPoints) == len(lastClosestPoints) and np.allclose(closestPoints, lastClosestPoints):
             interpolationLine = lastInterpolationLine
         else:
             interpolator = LagrangeApproximation(points = closestPoints)

--- a/tests/test_2_lagrange.py
+++ b/tests/test_2_lagrange.py
@@ -208,21 +208,21 @@ def testSparseInterpolation(inPoints, outPoints, order):
 @pytest.mark.parametrize('inPoints', [np.linspace(0, 1, 64, endpoint=False)])
 @pytest.mark.parametrize('outPoints', [np.linspace(0.123, 4.1214, 256, endpoint=False), np.linspace(0, 1, 128, endpoint=False)])
 @pytest.mark.parametrize('order', [2, 3, 4])
-def testSparseInterpolationPeriodic(inPoints, outPoints, order, grid_period=1):
+def testSparseInterpolationPeriodic(inPoints, outPoints, order, gridPeriod=1):
     """
     In this test, we do "extrapolation", which is really interpolation because of the periodicity of the grid.
     """
     from qmat.lagrange import getSparseInterpolationMatrix
     import scipy.sparse as sp
 
-    data = np.sin(inPoints * 2 * np.pi / grid_period)
+    data = np.sin(inPoints * 2 * np.pi / gridPeriod)
 
-    interpolationMatrix = getSparseInterpolationMatrix(inPoints, outPoints, order, grid_period=grid_period)
+    interpolationMatrix = getSparseInterpolationMatrix(inPoints, outPoints, order, gridPeriod=gridPeriod)
     assert isinstance(interpolationMatrix, sp.csc_matrix)
 
 
     interpolated = interpolationMatrix @ data
-    ref = np.sin(outPoints * 2* np.pi / grid_period)
+    ref = np.sin(outPoints * 2* np.pi / gridPeriod)
     error = np.linalg.norm(interpolated - ref)
 
     max_error = {


### PR DESCRIPTION
When doing interpolation on periodic grids, the nearest neighbors are different compared to non-periodic grids. For instance, the two nearest neighbors in a equispaced periodic grid of the first point are the second and last point, whereas the nearest points to the first point on a non-periodic equispaced grid are the second and third point.

Consider $\sin(x)$, with $x = [0, 2\pi)$ on a periodic grid. What do you get with extrapolation to $y = [2\pi, 4\pi)$? This is simply the next period, so you want to get the same solution as between $0$ and $2\pi$. But with second order interpolation that does not take periodicity into account, what you get is $\cos(2\pi) \times y$, i.e. it blows up.
This PR includes a test that indeed the periodic version does continue the sine wave rather than blowing up.

This arose from a very practical need. I am toying around with semi-Lagrangian methods. These are very stable, so you want to take large time steps. But then if the step size is large, chances are the departure point is beyond the domain limits. Without taking periodicity into account during the interpolation, my semi-Lagrangian methods would blow up with medium size step size. When taking periodicity into account, on the other hand, I can pretty much do arbitrarily large step size for a simple advection-diffusion problem.